### PR TITLE
Some clean-up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
           python3 -m pip install --upgrade pip pytest psycopg
           python3 -m pytest -vv test_action.py
         env:
-          PGPORT: 34837
           CONNECTION_URI: ${{ steps.postgres.outputs.connection-uri }}
           EXPECTED_CONNECTION_URI: postgresql://yoda:GrandMaster@localhost:34837/jedi_order
         shell: bash

--- a/action.yml
+++ b/action.yml
@@ -18,8 +18,8 @@ inputs:
     default: postgres
     required: false
   port:
-    description: The server port.
-    default: 5432
+    description: The server port to listen on.
+    default: "5432"
     required: false
 outputs:
   connection-uri:


### PR DESCRIPTION
* `inputs.port.default` is converted into string type explicitly since
  it must be a string (according to the docs) and because the linter
  complained.

* Remove `PGPORT` environment variable from CI since it seems unneeded.