### PR TITLE
Use encoding="UTF-8" and locale="en_US.UTF-8"

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,19 @@ key features:
 
 ```yaml
 steps:
-  - uses: ikalnytskyi/action-setup-postgres@v2
+  - uses: ikalnytskyi/action-setup-postgres@v3
 ```
 
 #### Advanced
 
 ```yaml
 steps:
-  - uses: ikalnytskyi/action-setup-postgres@v2
+  - uses: ikalnytskyi/action-setup-postgres@v3
     with:
       username: ci
       password: sw0rdfish
       database: test
-      port: "34837"
+      port: 34837
     id: postgres
 
   - run: pytest -vv tests/

--- a/action.yml
+++ b/action.yml
@@ -42,7 +42,7 @@ runs:
     - name: Setup and start PostgreSQL
       run: |
         export PGDATA="$RUNNER_TEMP/pgdata"
-        pg_ctl init
+        pg_ctl init --options="--encoding=UTF-8 --locale=en_US.UTF-8"
 
         # Forbid creating unix sockets since they are created by default in the
         # directory we don't have permissions to.


### PR DESCRIPTION
If not explicitly specified, PostgreSQL infers both locale and encoding
from the locale settings upon database initialization. Speaking about
GitHub runners, they all have different locale settings. For instance,
Windows runner uses `CP1252` encoding which renders the database unable
to deal with non-latin characters.
 
This patch enforces encoding="UTF-8" and locale="en_US.UTF-8" on all
supported platforms in order to ensure that the database behaves the
same way in certain edge cases.