### PR TITLE
Use `$GITHUB_OUTPUT` instead of `::set-output`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -79,6 +79,6 @@ runs:
     - name: Expose connection URI
       run: |
         CONNECTION_URI="postgresql://${{ inputs.username }}:${{ inputs.password }}@localhost:${{inputs.port}}/${{ inputs.database }}"
-        echo ::set-output name=value::$CONNECTION_URI
+        echo "value=$CONNECTION_URI" >> $GITHUB_OUTPUT
       shell: bash
       id: connection-uri


### PR DESCRIPTION
The `::set-output` command has been deprecated and is scheduled for removal on Jun 1, 2023 [1]. The recommended way to set output parameters today is by writing them to `$GITHUB_OUTPUT` file [2].

[1] https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ [2] https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter

Resolves: #6