### PR TITLE
BREAKING CHANGE: enforce password authentication

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,12 @@ runs:
     - name: Setup and start PostgreSQL
       run: |
         export PGDATA="$RUNNER_TEMP/pgdata"
+        export PWFILE="$RUNNER_TEMP/pwfile"
+
+        # Unfortunately 'initdb' could only receive a password via file on disk
+        # or prompt to enter on. Prompting is not an option since we're running
+        # in non-interactive mode.
+        echo '${{ inputs.password }}' > $PWFILE
 
         # There are couple of reasons why we need to create a new PostgreSQL
         # database cluster. First and foremost, we have to create a superuser
@@ -53,6 +59,8 @@ runs:
         # [1] https://www.postgresql.org/docs/15/reference-client.html
         initdb \
           --username="${{ inputs.username }}" \
+          --pwfile="$PWFILE" \
+          --auth="scram-sha-256" \
           --encoding="UTF-8" \
           --locale="en_US.UTF-8" \
           --no-instructions
@@ -69,13 +77,14 @@ runs:
         # PGHOST is required for Linux/macOS because we turned off unix sockets
         # and they use them by default.
         #
-        # PGPORT, PGUSER and PGDATABASE are required because they could be
-        # parametrized via action input parameters.
+        # PGPORT, PGUSER, PGPASSWORD and PGDATABASE are required because they
+        # could be parametrized via action input parameters.
         #
         # [1] https://www.postgresql.org/docs/15/reference-client.html
         echo "PGHOST=localhost" >> $GITHUB_ENV
         echo "PGPORT=${{ inputs.port }}" >> $GITHUB_ENV
         echo "PGUSER=${{ inputs.username }}" >> $GITHUB_ENV
+        echo "PGPASSWORD=${{ inputs.password }}" >> $GITHUB_ENV
         echo "PGDATABASE=${{ inputs.database }}" >> $GITHUB_ENV
       shell: bash
 

--- a/test_action.py
+++ b/test_action.py
@@ -146,7 +146,7 @@ def test_user_create_drop_user(
         connection.execute(f"DROP USER {username}")
 
 
-def test_client_applications(connection_uri, connection_factory):
+def test_client_applications(connection_factory: ConnectionFactory, connection_uri: str):
     """Test that PostgreSQL client applications can be used."""
 
     username = "us3rname"
@@ -167,3 +167,26 @@ def test_client_applications(connection_uri, connection_factory):
     finally:
         subprocess.check_call(["dropdb", database])
         subprocess.check_call(["dropuser", username])
+
+
+def test_auth_wrong_username(connection_factory: ConnectionFactory, connection_uri: str):
+    """Test that wrong username is rejected!"""
+
+    connection_furl = furl.furl(connection_uri, username="wrong")
+
+    with pytest.raises(psycopg.OperationalError) as excinfo:
+        connection_factory(connection_furl.url)
+
+    assert 'password authentication failed for user "wrong"' in str(excinfo.value)
+
+
+def test_auth_wrong_password(connection_factory: ConnectionFactory, connection_uri: str):
+    """Test that wrong password is rejected!"""
+
+    connection_furl = furl.furl(connection_uri, password="wrong")
+    username = connection_furl.username
+
+    with pytest.raises(psycopg.OperationalError) as excinfo:
+        connection_factory(connection_furl.url)
+
+    assert f'password authentication failed for user "{username}"' in str(excinfo.value)


### PR DESCRIPTION
It turns out that PostgreSQL comes with weird default that allows passwordless authentication for localhost connections [1]. This essentially means that 'password' input parameter for this action was ignored.

The 'setup-postgres' action's primary use case is to be used on CI where most of the time authentication is desired in order to verify that passwords are passed correctly from applications under test.

This patch enforces password authentication even for localhost connections, making sure that passwords are verified and not ignored. This will break everyone who previously passed wrong password or didn't pass it at all.

[1] https://www.postgresql.org/docs/15/auth-trust.html

Resolves #5