### PR TITLE
BREAKING CHANGE: don't set connection env vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,9 @@ jobs:
           python3 -m pytest -vv test_action.py
         env:
           CONNECTION_URI: ${{ steps.postgres.outputs.connection-uri }}
+          SERVICE_NAME: ${{ steps.postgres.outputs.service-name }}
           EXPECTED_CONNECTION_URI: postgresql://postgres:postgres@localhost:5432/postgres
+          EXPECTED_SERVICE_NAME: postgres
         shell: bash
 
   parametrized:
@@ -59,5 +61,7 @@ jobs:
           python3 -m pytest -vv test_action.py
         env:
           CONNECTION_URI: ${{ steps.postgres.outputs.connection-uri }}
+          SERVICE_NAME: ${{ steps.postgres.outputs.service-name }}
           EXPECTED_CONNECTION_URI: postgresql://yoda:GrandMaster@localhost:34837/jedi_order
+          EXPECTED_SERVICE_NAME: yoda
         shell: bash

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,10 @@ inputs:
 outputs:
   connection-uri:
     description: The connection URI to connect to PostgreSQL.
-    value: ${{ steps.connection-uri.outputs.value }}
+    value: ${{ steps.set-outputs.outputs.connection-uri }}
+  service-name:
+    description: The service name with connection parameters.
+    value: ${{ steps.set-outputs.outputs.service-name }}
 runs:
   using: composite
   steps:
@@ -71,21 +74,27 @@ runs:
         echo "port = ${{ inputs.port }}" >> "$PGDATA/postgresql.conf"
         pg_ctl start
 
-        # Set environment variables for PostgreSQL client applications [1] such
-        # as 'psql' or 'createuser'.
+        # Save required connection parameters for created superuser to the
+        # connection service file [1]. This allows using these connection
+        # parameters by setting 'PGSERVICE' environment variable or by
+        # requesting them via connection string.
         #
-        # PGHOST is required for Linux/macOS because we turned off unix sockets
-        # and they use them by default.
+        # HOST is required for Linux/macOS because these OS-es default to unix
+        # sockets but we turned them off.
         #
-        # PGPORT, PGUSER, PGPASSWORD and PGDATABASE are required because they
-        # could be parametrized via action input parameters.
+        # PORT, USER, PASSWORD and DBNAME are required because they could be
+        # parametrized via action input parameters.
         #
-        # [1] https://www.postgresql.org/docs/15/reference-client.html
-        echo "PGHOST=localhost" >> $GITHUB_ENV
-        echo "PGPORT=${{ inputs.port }}" >> $GITHUB_ENV
-        echo "PGUSER=${{ inputs.username }}" >> $GITHUB_ENV
-        echo "PGPASSWORD=${{ inputs.password }}" >> $GITHUB_ENV
-        echo "PGDATABASE=${{ inputs.database }}" >> $GITHUB_ENV
+        # [1] https://www.postgresql.org/docs/15/libpq-pgservice.html
+        cat <<EOF > "$PGDATA/pg_service.conf"
+        [${{ inputs.username }}]
+        host=localhost
+        port=${{ inputs.port }}
+        user=${{ inputs.username }}
+        password=${{ inputs.password }}
+        dbname=${{ inputs.database }}
+        EOF
+        echo "PGSERVICEFILE=$PGDATA/pg_service.conf" >> $GITHUB_ENV
       shell: bash
 
     - name: Setup PostgreSQL database
@@ -97,11 +106,15 @@ runs:
         if [ "${{ inputs.database }}" != "postgres" ]; then
           createdb -O "${{ inputs.username }}" "${{ inputs.database }}"
         fi
+      env:
+        PGSERVICE: ${{ inputs.username }}
       shell: bash
 
-    - name: Expose connection URI
+    - name: Set action outputs
       run: |
-        CONNECTION_URI="postgresql://${{ inputs.username }}:${{ inputs.password }}@localhost:${{inputs.port}}/${{ inputs.database }}"
-        echo "value=$CONNECTION_URI" >> $GITHUB_OUTPUT
+        CONNECTION_URI="postgresql://${{ inputs.username }}:${{ inputs.password }}@localhost:${{ inputs.port }}/${{ inputs.database }}"
+
+        echo "connection-uri=$CONNECTION_URI" >> $GITHUB_OUTPUT
+        echo "service-name=${{ inputs.username }}" >> $GITHUB_OUTPUT
       shell: bash
-      id: connection-uri
+      id: set-outputs


### PR DESCRIPTION
The 'setup-postgres' action used to set libpq environment variables [1] with connection parameters so the PostgreSQL client applications [2], such as 'psql' or 'createuser', won't require any configuration before using.

Unfortunately these libpq environment variables are also used by all libpq clients including database drivers such as 'psycopg'. While this may sound good, it may as well lead to undesired behaviour and unobvious issues when connection parameters are automatically pulled from environment but most not.

Nevertheless, the need to easy usage of the client applications [2] is indisputable because providing a bunch of connection parameters all the time is tedious. Therefore this patch pushes requires connection parameters to the connection service file [3], so the client applications can pull the data on-demand. E.g:

```console
$ psql service=superuser -c "SELECT 1;"
$ PGSERVICE=superuser createuser myuser
```

[1] https://www.postgresql.org/docs/15/libpq-envars.html
[2] https://www.postgresql.org/docs/15/reference-client.html
[3] https://www.postgresql.org/docs/15/libpq-pgservice.html