### PR TITLE
CI: Bump actions/checkout to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
           - windows-latest
           - macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Run setup-postgres
         uses: ./
@@ -44,7 +44,7 @@ jobs:
           - windows-latest
           - macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Run setup-postgres
         uses: ./


### PR DESCRIPTION
The checkout v2, the version currently in use on CI, depends on node12 which is going to be removed soon. Let's use the latest version in order to get rid of deprecation warnings in logs and remain compatible with GitHun runners.