### PR TITLE
Add macOS 13 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macos-latest
+          - macos-13
     steps:
       - uses: actions/checkout@v4
 

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,14 @@ runs:
         elif [ "$RUNNER_OS" == "Windows" ]; then
           echo "$PGBIN" >> $GITHUB_PATH
           echo "PQ_LIB_DIR=$PGROOT\lib" >> $GITHUB_ENV
+        elif [ "$RUNNER_OS" == "macOS" ]; then
+          case "$(sw_vers -productVersion)" in
+            13.*)
+              # Unfortunately, the macOS 13 runner image doesn't come w/
+              # pre-installed PostgreSQL server.
+              brew install postgresql@14
+              ;;
+          esac
         fi
       shell: bash
 


### PR DESCRIPTION
The macOS 13 runner image isn't shipped with pre-installed PostgreSQL server. Even though it has Beta status, it'd be nice to support this runner image too.