### PR TITLE
Unset PG* env vars except PGSERVICEFILE

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ key features:
 
 ## Usage
 
+> [!IMPORTANT]
+>
+> In order to connect to a PostgreSQL server, use either connection parameters
+> from the table below ([link](#connection-parameters)), or retrieve a
+> connection URI from the `connection-uri` output ([link](#advanced)).
+
+> [!TIP]
+>
+> `libpq`-using applications may choose to set the `PGSERVICE=postgres`
+> environment variable instead ([link](#create-a-new-user-w-database-via-cli)),
+> where `postgres` is the service name extracted from the `service-name`
+> output.
+
 #### Connection parameters
 
 | Key      | Value                                               |
@@ -73,11 +86,10 @@ steps:
       createuser myuser
       createdb --owner myuser mydatabase
       psql -c "ALTER USER myuser WITH PASSWORD 'mypassword'"
-
     env:
       # This activates connection parameters for the superuser created by
       # the action in the step above. It's mandatory to set this before using
-      # createuser/psql/etc tools.
+      # createuser/psql and other libpq-using applications.
       #
       # The service name is the same as the username (i.e. 'postgres') but
       # it's recommended to use action's output to get the name in order to

--- a/action.yml
+++ b/action.yml
@@ -38,6 +38,13 @@ runs:
         elif [ "$RUNNER_OS" == "Windows" ]; then
           echo "$PGBIN" >> $GITHUB_PATH
           echo "PQ_LIB_DIR=$PGROOT\lib" >> $GITHUB_ENV
+
+          # The Windows runner has some PostgreSQL environment variables set
+          # that may confuse users since they may be irrelevant to the
+          # PostgreSQL server we're using.
+          for name in "PGROOT" "PGDATA" "PGBIN" "PGUSER" "PGPASSWORD"; do
+            echo "$name=" >> $GITHUB_ENV
+          done
         elif [ "$RUNNER_OS" == "macOS" ]; then
           case "$(sw_vers -productVersion)" in
             13.*)


### PR DESCRIPTION
Unfortunately, the Windows runner has some PostgreSQL environment
variables set, which are neither set for Linux or macOS runners. This is
may be especially confusing since variables such as PGUSER or PGPASSWORD
may point to a user that doesn't exist.

Since one of the design decisions made previously is to restrain this
action from pointing to any user by default, we better unset these
environment variables to avoid confusion.

In addition to that change, let's also mention in the README file that
it's up to users to set connection parameters whatever way they prefer.

Reported-by: @bkoelman
Fixes: #17