### PR TITLE
Support macOS 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           - windows-latest
           - macos-latest
           - macos-13
+          - macos-14
     steps:
       - uses: actions/checkout@v4
 
@@ -44,9 +45,51 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macos-latest
+          - macos-13
+          - macos-14
     steps:
       - uses: actions/checkout@v4
 
+      - name: Run setup-postgres
+        uses: ./
+        with:
+          username: yoda
+          password: GrandMaster
+          database: jedi_order
+          port: 34837
+        id: postgres
+
+      - name: Run tests
+        run: |
+          python3 -m pip install --upgrade pip pytest psycopg furl
+          python3 -m pytest -vv test_action.py
+        env:
+          CONNECTION_URI: ${{ steps.postgres.outputs.connection-uri }}
+          SERVICE_NAME: ${{ steps.postgres.outputs.service-name }}
+          EXPECTED_CONNECTION_URI: postgresql://yoda:GrandMaster@localhost:34837/jedi_order
+          EXPECTED_SERVICE_NAME: yoda
+        shell: bash
+
+  previousBrewSetup:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          # brew does not support Windows
+          - ubuntu-latest
+          - macos-latest
+          - macos-13
+          - macos-14
+
+    env:
+      # Disable auto updating outdated unrelated packages to the latest versions
+      HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: true
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: Homebrew/actions/setup-homebrew@master
+        id: set-up-homebrew
       - name: Run setup-postgres
         uses: ./
         with:

--- a/action.yml
+++ b/action.yml
@@ -46,11 +46,18 @@ runs:
             echo "$name=" >> $GITHUB_ENV
           done
         elif [ "$RUNNER_OS" == "macOS" ]; then
+
+          # macOS 12 is the only runner having postgresql@14 preinstalled,
+          # but reinstalling it is a no-op.
+          brew install postgresql@14
+
           case "$(sw_vers -productVersion)" in
-            13.*)
-              # Unfortunately, the macOS 13 runner image doesn't come w/
-              # pre-installed PostgreSQL server.
-              brew install postgresql@14
+            12.*|13.*)
+              echo "/usr/local/opt/postgresql@14/bin" >> $GITHUB_PATH
+              ;;
+            14.*)
+              # Starting macOS 14 Homebrew switched to /opt/homebrew 
+              echo "/opt/homebrew/opt/postgresql@14/bin" >> $GITHUB_PATH
               ;;
           esac
         fi


### PR DESCRIPTION
[macOS 14 runners are GA and free for public repos](https://github.com/actions/runner-images/issues/9254), but they also do [not have postgresql preinstalled](https://github.com/actions/runner-images/blob/macOS-12/20240218.1/images/macos/macos-14-arm64-Readme.md) so calling initdb fails.

macOS 12 (ignoring the deprecated macOS 11) is the only one with postgresql preinstalled, but reinstalling the same version is a no-op.

It also aligns with the planned `version` input someday.