### PR TITLE
Fix macOS 13 support

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,10 @@ runs:
             13.*)
               # Unfortunately, the macOS 13 runner image doesn't come w/
               # pre-installed PostgreSQL server.
-              brew install postgresql@14
+              export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
+              export HOMEBREW_NO_INSTALL_CLEANUP=1
+              export HOMEBREW_NO_INSTALL_UPGRADE=1
+              brew install --skip-post-install postgresql@14
               ;;
           esac
         fi


### PR DESCRIPTION
Due to some dark magic used to prepare the macOS 13 runner, the brew install command fails to link unrelated kegs, such as `python@3.12`. Fortunately, since `python@3.12` is a dependency of a dependency, and that dependency is already installed, we can workaround the issue by forcing Homebrew to do not try upgrading dependencies unless absolutely neccessary.

Fixes: #27