### PR TITLE
Add macOS 14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           - windows-latest
           - macos-latest
           - macos-13
+          - macos-14
     steps:
       - uses: actions/checkout@v4
 

--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
           done
         elif [ "$RUNNER_OS" == "macOS" ]; then
           case "$(sw_vers -productVersion)" in
-            13.*)
+            13.*|14.*)
               # Unfortunately, the macOS 13 runner image doesn't come w/
               # pre-installed PostgreSQL server.
               export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1


### PR DESCRIPTION
The macOS 14 runner image isn't shipped with pre-installed PostgreSQL server. Even though it has Beta status, it'd be nice to support this runner image too.