### PR TITLE
Add support for missing action runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,17 +14,24 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
-          - macos-13
+          - ubuntu-22.04
+          - ubuntu-20.04
+          - windows-2022
+          - windows-2019
           - macos-14
+          - macos-13
+          - macos-12
     steps:
       - uses: actions/checkout@v4
 
       - name: Run setup-postgres
         uses: ./
         id: postgres
+
+      - name: Run setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
 
       - name: Run tests
         run: |
@@ -56,6 +63,11 @@ jobs:
           database: jedi_order
           port: 34837
         id: postgres
+
+      - name: Run setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
 
       - name: Run tests
         run: |

--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,18 @@ runs:
         export PGDATA="$RUNNER_TEMP/pgdata"
         export PWFILE="$RUNNER_TEMP/pwfile"
 
+        DEFAULT_ENCODING="UTF-8"
+        DEFAULT_LOCALE="en_US.$DEFAULT_ENCODING"
+
+        # Unfortunately, Windows Server 2019 doesn't understand locale
+        # specified in the format defined by the POSIX standard, i.e.
+        # <language>_<country>.<encoding>. Therefore, we have to convert it
+        # into something it can swallow, i.e. <language>-<country>.
+        if [[ "$RUNNER_OS" == "Windows" && "$(wmic os get Caption)" == *"2019"* ]]; then
+          DEFAULT_LOCALE="${DEFAULT_LOCALE%%.*}"
+          DEFAULT_LOCALE="${DEFAULT_LOCALE//_/-}"
+        fi
+
         # Unfortunately 'initdb' could only receive a password via file on disk
         # or prompt to enter on. Prompting is not an option since we're running
         # in non-interactive mode.
@@ -82,8 +94,8 @@ runs:
           --username="${{ inputs.username }}" \
           --pwfile="$PWFILE" \
           --auth="scram-sha-256" \
-          --encoding="UTF-8" \
-          --locale="en_US.UTF-8" \
+          --encoding="$DEFAULT_ENCODING" \
+          --locale="$DEFAULT_LOCALE" \
           --no-instructions
 
         # Do not create unix sockets since they are created by default in the


### PR DESCRIPTION
Turns out that Windows Server 2019 does not support locale names specified in the format defined by the POSIX standard. This patch converts the POSIX format to the one supported by Windows 2019.

In addition to that, this patch adds all supported action runners to the continue integration, so we can make sure that this action works properly on every supported platform.

Reported-by: Irena Rindos
Fixes: #25
