### PR TITLE
Use a system-wide pg_service.conf

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-22.04
-          - ubuntu-20.04
+          # - ubuntu-22.04
+          # - ubuntu-20.04
           - windows-2022
-          - windows-2019
-          - macos-14
-          - macos-13
-          - macos-12
+          # - windows-2019
+          # - macos-14
+          # - macos-13
+          # - macos-12
     steps:
       - uses: actions/checkout@v4
 
@@ -32,6 +32,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.10"
+
+      - uses: mxschmitt/action-tmate@v3
 
       - name: Run tests
         run: |

--- a/action.yml
+++ b/action.yml
@@ -103,20 +103,14 @@ runs:
         echo "unix_socket_directories = ''" >> "$PGDATA/postgresql.conf"
         echo "port = ${{ inputs.port }}" >> "$PGDATA/postgresql.conf"
         pg_ctl start
+      shell: bash
 
-        # Save required connection parameters for created superuser to the
-        # connection service file [1]. This allows using these connection
-        # parameters by setting 'PGSERVICE' environment variable or by
-        # requesting them via connection string.
-        #
-        # HOST is required for Linux/macOS because these OS-es default to unix
-        # sockets but we turned them off.
-        #
-        # PORT, USER, PASSWORD and DBNAME are required because they could be
-        # parametrized via action input parameters.
-        #
-        # [1] https://www.postgresql.org/docs/15/libpq-pgservice.html
-        cat <<EOF > "$PGDATA/pg_service.conf"
+    - name: Setup the connection service file
+      run: |
+        PGSERVICEFILE="$(pg_config --sysconfdir)/pg_service.conf"
+        PGSERVICEFILE_TMP="$RUNNER_TEMP/pg_service.conf"
+
+        cat << EOF > "$PGSERVICEFILE_TMP"
         [${{ inputs.username }}]
         host=localhost
         port=${{ inputs.port }}
@@ -124,7 +118,15 @@ runs:
         password=${{ inputs.password }}
         dbname=${{ inputs.database }}
         EOF
-        echo "PGSERVICEFILE=$PGDATA/pg_service.conf" >> $GITHUB_ENV
+
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          SUDO=""
+        else
+          SUDO="sudo"
+        fi
+
+        $SUDO mkdir -p "$(dirname "$PGSERVICEFILE")"
+        $SUDO mv "$PGSERVICEFILE_TMP" "$PGSERVICEFILE"
       shell: bash
 
     - name: Setup PostgreSQL database

--- a/test_action.py
+++ b/test_action.py
@@ -113,12 +113,6 @@ def test_environment_variables(is_windows: bool):
 
     pg_environ = {k: v for k, v in os.environ.items() if k.startswith("PG")}
 
-    # In case of Windows, there might be a mix of forward and backward slashes
-    # as separators. So let's compare paths semantically instead.
-    pg_servicefile = pathlib.Path(pg_environ.pop("PGSERVICEFILE", ""))
-    pg_servicefile_exp = pathlib.Path(os.environ["RUNNER_TEMP"], "pgdata", "pg_service.conf")
-    assert pg_servicefile.resolve() == pg_servicefile_exp.resolve()
-    
     if is_windows:
         pg_environ_exp = {
             "PGBIN": "",


### PR DESCRIPTION
The connection service file allows libpq connection parameters to be associated with a single service name. Service names can be defined in either a per-user service file or a system-wide file. If the same service name exists in both the user and the system file, the user file takes precedence.

Not being experienced enough with service files, I went with a per-user service file initially, stored in non-default location. This means action users cannot easily supply its own service file without overwriting environment variables or modifying the service file supplied by this action.

It seems more reasonable to have a system-wide service file located at the default location, rather than supply a per-user one and configure PGSERVICEFILE to point to the latter. Additionally, it may help to bypass crashes in third party applications which are not ready for PGSERVICEFILE being set (e.g. dbmate).

Fixes: #40