### PR TITLE
Add SSL support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,14 +40,16 @@ jobs:
 
       - name: Run tests
         run: |
-          python3 -m pip install --upgrade pip pytest psycopg furl
+          python3 -m pip install --upgrade pip pytest psycopg furl cryptography
           python3 -m pytest -vv test_action.py
         env:
           CONNECTION_URI: ${{ steps.postgres.outputs.connection-uri }}
           SERVICE_NAME: ${{ steps.postgres.outputs.service-name }}
+          CERTIFICATE_PATH: ${{ steps.postgres.outputs.certificate-path }}
           EXPECTED_CONNECTION_URI: postgresql://postgres:postgres@localhost:5432/postgres
           EXPECTED_SERVICE_NAME: postgres
           EXPECTED_SERVER_VERSION: "16"
+          EXPECTED_SSL: false
 
   parametrized:
     runs-on: ${{ matrix.os }}
@@ -76,6 +78,7 @@ jobs:
           database: jedi_order
           port: 34837
           postgres-version: ${{ matrix.postgres-version }}
+          ssl: true
         id: postgres
 
       - name: Run setup-python
@@ -85,11 +88,13 @@ jobs:
 
       - name: Run tests
         run: |
-          python3 -m pip install --upgrade pip pytest psycopg furl
+          python3 -m pip install --upgrade pip pytest psycopg furl cryptography
           python3 -m pytest -vv test_action.py
         env:
           CONNECTION_URI: ${{ steps.postgres.outputs.connection-uri }}
           SERVICE_NAME: ${{ steps.postgres.outputs.service-name }}
-          EXPECTED_CONNECTION_URI: postgresql://yoda:GrandMaster@localhost:34837/jedi_order
+          CERTIFICATE_PATH: ${{ steps.postgres.outputs.certificate-path }}
+          EXPECTED_CONNECTION_URI: postgresql://yoda:GrandMaster@localhost:34837/jedi_order?sslmode=verify-ca&sslrootcert=${{ steps.postgres.outputs.certificate-path }}
           EXPECTED_SERVICE_NAME: yoda
           EXPECTED_SERVER_VERSION: ${{ matrix.postgres-version }}
+          EXPECTED_SSL: true

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ key features:
 * Runs on Linux, macOS and Windows action runners.
 * Adds PostgreSQL [client applications][1] to `PATH`.
 * PostgreSQL version can be parametrized.
+* Supports SSL if needed.
 * Easy [to verify][2] that it DOES NOT contain malicious code.
 
 By default PostgreSQL 15 is used.
@@ -44,10 +45,11 @@ By default PostgreSQL 15 is used.
 
 #### Outputs
 
-| Key            | Description                                  | Example                                             |
-|----------------|----------------------------------------------|-----------------------------------------------------|
-| connection-uri | The connection URI to connect to PostgreSQL. | `postgresql://postgres:postgres@localhost/postgres` |
-| service-name   | The service name with connection parameters. | `postgres`                                          |
+| Key              | Description                                      | Example                                             |
+|------------------|--------------------------------------------------|-----------------------------------------------------|
+| connection-uri   | The connection URI to connect to PostgreSQL.     | `postgresql://postgres:postgres@localhost/postgres` |
+| service-name     | The service name with connection parameters.     | `postgres`                                          |
+| certificate-path | The path to the server certificate if SSL is on. | `/home/runner/work/_temp/pgdata/server.crt`         |
 
 #### User permissions
 
@@ -74,6 +76,7 @@ steps:
       database: test
       port: 34837
       postgres-version: "14"
+      ssl: "on"
     id: postgres
 
   - run: pytest -vv tests/

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,9 @@ inputs:
   postgres-version:
     description: The PostgreSQL major version to install. Either "14", "15", or "16".
     default: "16"
+  ssl:
+    description: When "true", encrypt connections using SSL (TLS).
+    default: "false"
     required: false
 outputs:
   connection-uri:
@@ -32,6 +35,9 @@ outputs:
   service-name:
     description: The service name with connection parameters.
     value: ${{ steps.set-outputs.outputs.service-name }}
+  certificate-path:
+    description: The path to the server certificate if SSL is on.
+    value: ${{ steps.set-outputs.outputs.certificate-path }}
 runs:
   using: composite
   steps:
@@ -132,6 +138,23 @@ runs:
         # directory we have no permissions to (owned by system postgres user).
         echo "unix_socket_directories = ''" >> "$PGDATA/postgresql.conf"
         echo "port = ${{ inputs.port }}" >> "$PGDATA/postgresql.conf"
+
+        if [ "${{ inputs.ssl }}" = "true" ]; then
+          # On Windows, bash runs on top of MSYS2, which automatically converts
+          # Unix paths to Windows paths for every argument that appears to be a
+          # path. This behavior breaks the openssl invocation because the
+          # subject argument is mistakenly converted when it should not be.
+          # Therefore, we need to exclude it from the path conversion process
+          # by setting the MSYS2_ARG_CONV_EXCL environment variable.
+          #
+          # https://www.msys2.org/docs/filesystem-paths/#automatic-unix-windows-path-conversion
+          export MSYS2_ARG_CONV_EXCL="/CN"
+          openssl req -new -x509 -days 365 -nodes -text -subj "/CN=localhost" \
+            -out "$PGDATA/server.crt" -keyout "$PGDATA/server.key"
+          chmod og-rwx "$PGDATA/server.key" "$PGDATA/server.crt"
+          echo "ssl = on" >> "$PGDATA/postgresql.conf"
+        fi
+
         pg_ctl start --pgdata="$PGDATA"
 
         # Save required connection parameters for created superuser to the
@@ -154,6 +177,12 @@ runs:
         password=${{ inputs.password }}
         dbname=${{ inputs.database }}
         EOF
+
+        if [ "${{ inputs.ssl }}" = "true" ]; then
+          echo "sslmode=verify-ca" >> "$PGDATA/pg_service.conf"
+          echo "sslrootcert=$PGDATA/server.crt" >> "$PGDATA/pg_service.conf"
+        fi
+
         echo "PGSERVICEFILE=$PGDATA/pg_service.conf" >> $GITHUB_ENV
       shell: bash
 
@@ -173,6 +202,17 @@ runs:
     - name: Set action outputs
       run: |
         CONNECTION_URI="postgresql://${{ inputs.username }}:${{ inputs.password }}@localhost:${{ inputs.port }}/${{ inputs.database }}"
+        CERTIFICATE_PATH="$RUNNER_TEMP/pgdata/server.crt"
+
+        if [ "${{ inputs.ssl }}" = "true" ]; then
+          # Although SSLMODE and SSLROOTCERT are specific to libpq options,
+          # most third-party drivers also support them. By default libpq
+          # prefers SSL but doesn't require it, thus it's important to set
+          # these options to ensure SSL is used and the certificate is
+          # verified.
+          CONNECTION_URI="$CONNECTION_URI?sslmode=verify-ca&sslrootcert=$CERTIFICATE_PATH"
+          echo "certificate-path=$CERTIFICATE_PATH" >> $GITHUB_OUTPUT
+        fi
 
         echo "connection-uri=$CONNECTION_URI" >> $GITHUB_OUTPUT
         echo "service-name=${{ inputs.username }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
There are two cases when PostgreSQL with SSL enabled may come handy. The first one is when PostgreSQL driver developers want to test SSL support in their drivers. The second one is when you come to depend on some self-signed certificates and you want to test your application end-to-end, i.e. with certificates being used.