### PR TITLE
Change readme to mention v16 default

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ key features:
 * Supports SSL if needed.
 * Easy [to verify][2] that it DOES NOT contain malicious code.
 
-By default PostgreSQL 15 is used.
+By default PostgreSQL 16 is used.
 
 [1]: https://www.postgresql.org/docs/current/reference-client.html
 [2]: action.yml


### PR DESCRIPTION
Originally the v16 default was added in this commit:

- https://github.com/ikalnytskyi/action-setup-postgres/commit/b5b4c349fc726b8eba33c19f7f6e4df3156f01da

Most of the commit is about v16 as a default, and then parts of the commit only add v15.

I'm assuming that it was intended for v16 to be the default, since the `action.yml` has `16` as the default:

https://github.com/ikalnytskyi/action-setup-postgres/blob/079b07305688c24b4e4c96ec686bd542ede25e05/action.yml#L24-L26