### PR TITLE
Suppress Homebrew warnings

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -82,15 +82,20 @@ runs:
           echo "PQ_LIB_DIR=$PG_LIBDIR" >> $GITHUB_ENV
 
         elif [ "$RUNNER_OS" == "macOS" ]; then
+          export HOMEBREW_NO_ENV_HINTS=1
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
           export HOMEBREW_NO_INSTALL_CLEANUP=1
           export HOMEBREW_NO_INSTALL_UPGRADE=1
-          brew install --skip-post-install postgresql@${{ inputs.postgres-version }}
+          brew install --quiet --skip-post-install postgresql@${{ inputs.postgres-version }}
 
           # Link PostgreSQL binaries from /usr/local/bin in order to make them
-          # available globally. The overwrite option is required since some
-          # GitHub runners come with preinstalled PostgreSQL binaries.
-          brew link --overwrite postgresql@${{ inputs.postgres-version }}
+          # available globally. The --overwrite option is required since some
+          # GitHub runners come with preinstalled PostgreSQL binaries, and we
+          # have to link the required version of PostgreSQL. The unlinking step
+          # is needed to suppress "Already linked" warning which is propagated
+          # back to users.
+          brew unlink --quiet postgresql@${{ inputs.postgres-version }}
+          brew link --quiet --overwrite postgresql@${{ inputs.postgres-version }}
         fi
       shell: bash
 


### PR DESCRIPTION
When `brew` is used by this action, it generates a bunch of warnings which are picked up by the github actions capture system and are shown to end users. They are noisy and most of them are expected. In order to avoid alerting end users, this patch suppresses them by passing 'quiet' parameter to the `brew` binary, unlinking linked keg and suppressing env hints.