### PR TITLE
Drop macOS 12 support, add macOS 15 instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
           - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
-          - macos-12
           - macos-13
           - macos-14
+          - macos-15
           - windows-2019
           - windows-2022
     steps:
@@ -59,9 +59,9 @@ jobs:
           - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
-          - macos-12
           - macos-13
           - macos-14
+          - macos-15
           - windows-2019
           - windows-2022
         postgres-version:


### PR DESCRIPTION
The macOS 12 actions runner has been deprecated on 2024-10-07 and is planned for complete removal on 2024-12-03 [^1]. I believe it's about time to stop using macOS 12, and instead cover macOS 15 (beta) instead.

[^1]: https://github.com/actions/runner-images/issues/10721