### PR TITLE
Remove retired runners from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,14 +18,13 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
           - macos-13
           - macos-14
           - macos-15
-          - windows-2019
           - windows-2022
+          - windows-2025
     steps:
       - uses: actions/checkout@v4
 
@@ -56,14 +55,13 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
           - ubuntu-22.04
           - ubuntu-24.04
           - macos-13
           - macos-14
           - macos-15
-          - windows-2019
           - windows-2022
+          - windows-2025
         postgres-version:
           - "14"
           - "15"

--- a/action.yml
+++ b/action.yml
@@ -111,15 +111,6 @@ runs:
         DEFAULT_ENCODING="UTF-8"
         DEFAULT_LOCALE="en_US.$DEFAULT_ENCODING"
 
-        # Unfortunately, Windows Server 2019 doesn't understand locale
-        # specified in the format defined by the POSIX standard, i.e.
-        # <language>_<country>.<encoding>. Therefore, we have to convert it
-        # into something it can swallow, i.e. <language>-<country>.
-        if [[ "$RUNNER_OS" == "Windows" && "$(wmic os get Caption)" == *"2019"* ]]; then
-          DEFAULT_LOCALE="${DEFAULT_LOCALE%%.*}"
-          DEFAULT_LOCALE="${DEFAULT_LOCALE//_/-}"
-        fi
-
         # Unfortunately 'initdb' could only receive a password via file on disk
         # or prompt to enter on. Prompting is not an option since we're running
         # in non-interactive mode.

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -21,17 +21,6 @@ def is_windows() -> bool:
 
 
 @pytest.fixture(scope="function")
-def is_windows_server_2019(is_windows: bool) -> bool:
-    """Returns True if running on Windows Server 2019."""
-
-    if not is_windows:
-        return False
-
-    windows_caption = subprocess.check_output(["wmic", "os", "get", "Caption"], text=True)
-    return "Windows Server 2019" in windows_caption
-
-
-@pytest.fixture(scope="function")
 def connection_uri() -> str:
     """Read and return connection URI from environment."""
 
@@ -108,27 +97,24 @@ def test_server_encoding(connection: psycopg.Connection):
     assert connection.execute("SHOW SERVER_ENCODING").fetchone()[0] == "UTF8"
 
 
-def test_locale(connection: psycopg.Connection, is_windows_server_2019: bool):
-    """Test that PostgreSQL's locale matches the one we paased to initdb."""
+def test_locale(connection: psycopg.Connection):
+    """Test that PostgreSQL's locale matches the one we passed to initdb."""
 
-    locale_exp = "en_US.UTF-8"
-
-    if is_windows_server_2019:
-        locale_exp = "en-US"
+    locale_expected = "en_US.UTF-8"
 
     record = connection \
         .execute("SELECT datcollate, datctype FROM pg_database WHERE datname = 'template0'") \
         .fetchone()
     assert record
-    assert locale.normalize(record[0]) == locale_exp
-    assert locale.normalize(record[1]) == locale_exp
+    assert locale.normalize(record[0]) == locale_expected
+    assert locale.normalize(record[1]) == locale_expected
 
     record = connection \
         .execute("SELECT datcollate, datctype FROM pg_database WHERE datname = 'template1'") \
         .fetchone()
     assert record
-    assert locale.normalize(record[0]) == locale_exp
-    assert locale.normalize(record[1]) == locale_exp
+    assert locale.normalize(record[0]) == locale_expected
+    assert locale.normalize(record[1]) == locale_expected
 
 
 def test_environment_variables(is_windows: bool):


### PR DESCRIPTION
Both Ubuntu 20.04 and Windows 2019 runners have been retired and are no longer available.