### PR TITLE
Replace macOS 13 with macOS 26 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,9 +22,10 @@ jobs:
           - ubuntu-22.04-arm
           - ubuntu-24.04
           - ubuntu-24.04-arm
-          - macos-13
           - macos-14
           - macos-15
+          - macos-15-intel
+          - macos-26
           - windows-11-arm
           - windows-2022
           - windows-2025
@@ -66,9 +67,10 @@ jobs:
           - ubuntu-22.04-arm
           - ubuntu-24.04
           - ubuntu-24.04-arm
-          - macos-13
           - macos-14
           - macos-15
+          - macos-15-intel
+          - macos-26
           - windows-11-arm
           - windows-2022
           - windows-2025


### PR DESCRIPTION
macOS 13 runners are deprecated and will reach end-of-life soon. Replace them with macOS 26 runners.