### PR TITLE
Add PostgreSQL 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           CERTIFICATE_PATH: ${{ steps.postgres.outputs.certificate-path }}
           EXPECTED_CONNECTION_URI: postgresql://postgres:postgres@localhost:5432/postgres
           EXPECTED_SERVICE_NAME: postgres
-          EXPECTED_SERVER_VERSION: "17"
+          EXPECTED_SERVER_VERSION: "18"
           EXPECTED_SSL: false
 
   parametrized:
@@ -78,6 +78,7 @@ jobs:
           - "14"
           - "15"
           - "16"
+          - "17"
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,13 @@ key features:
 
 #### Inputs
 
-| Key              | Value                                                                              | Default     |
-|------------------|------------------------------------------------------------------------------------|-------------|
-| username         | The username of the user to setup.                                                 | `postgres`  |
-| password         | The password of the user to setup.                                                 | `postgres`  |
-| database         | The database name to setup and grant permissions to created user.                  | `postgres`  |
-| port             | The server port to listen on.                                                      | `5432`      |
-| postgres-version | The PostgreSQL major version to install. Supported values: "14", "15", "16", "17". | `17`        |
+| Key              | Value                                                                                    | Default     |
+|------------------|------------------------------------------------------------------------------------------|-------------|
+| username         | The username of the user to setup.                                                       | `postgres`  |
+| password         | The password of the user to setup.                                                       | `postgres`  |
+| database         | The database name to setup and grant permissions to created user.                        | `postgres`  |
+| port             | The server port to listen on.                                                            | `5432`      |
+| postgres-version | The PostgreSQL major version to install. Supported values: "14", "15", "16", "17", "18". | `18`        |
 
 #### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -22,8 +22,8 @@ inputs:
     default: "5432"
     required: false
   postgres-version:
-    description: The PostgreSQL major version to install. Either "14", "15", "16" or "17".
-    default: "17"
+    description: The PostgreSQL major version to install. Either "14", "15", "16", "17" or "18".
+    default: "18"
   ssl:
     description: When "true", encrypt connections using SSL (TLS).
     default: "false"
@@ -43,8 +43,8 @@ runs:
   steps:
     - name: Install PostgreSQL
       run: |
-        if [[ ! "${{ inputs.postgres-version }}" =~ ^(14|15|16|17)$ ]]; then
-          echo "::error::postgres-version must be one of: 14, 15, 16, 17."
+        if [[ ! "${{ inputs.postgres-version }}" =~ ^(14|15|16|17|18)$ ]]; then
+          echo "::error::postgres-version must be one of: 14, 15, 16, 17, 18."
           exit 1
         fi
 


### PR DESCRIPTION
PostgreSQL 18 is the most recent version of the PostgreSQL database, released on September 25, 2025. It just makes sense to keep up with the upstream versions if we can, hence this patch.