### PR TITLE
Add ubuntu-slim runner to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
     strategy:
       matrix:
         os:
+          - ubuntu-slim
           - ubuntu-22.04
           - ubuntu-22.04-arm
           - ubuntu-24.04
@@ -67,6 +68,7 @@ jobs:
     strategy:
       matrix:
         os:
+          - ubuntu-slim
           - ubuntu-22.04
           - ubuntu-22.04-arm
           - ubuntu-24.04

--- a/action.yml
+++ b/action.yml
@@ -118,6 +118,14 @@ runs:
         DEFAULT_ENCODING="UTF-8"
         DEFAULT_LOCALE="en_US.$DEFAULT_ENCODING"
 
+        # Some runners (e.g., `ubuntu-slim`) may not include the `en_US.UTF-8`
+        # locale by default. Ensure the required locale exists by generating it
+        # if missing.
+        if ! python -c "from locale import *; setlocale(LC_ALL, '$DEFAULT_LOCALE')" \
+             >/dev/null 2>&1; then
+          sudo locale-gen "$DEFAULT_LOCALE"
+        fi
+
         # Unfortunately 'initdb' could only receive a password via file on disk
         # or prompt to enter on. Prompting is not an option since we're running
         # in non-interactive mode.


### PR DESCRIPTION
GitHub Actions 1 vCPU Linux runners are now in public preview. Customers looking to run lightweight operations can take advantage of these lower cost runners[^1]. This patch adds ubuntu-slim runner to the CI matrix.

[^1]: https://github.blog/changelog/2025-10-28-1-vcpu-linux-runner-now-available-in-github-actions-in-public-preview/