### PR TITLE
Retry choco install on Windows to absorb transient download failures

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -74,10 +74,26 @@ runs:
             echo "$name=" >> $GITHUB_ENV
           done
 
-          choco install postgresql$INPUT_POSTGRES_VERSION \
-            --params "/Password:$INPUT_PASSWORD" \
-            --ia "--enable-components server,commandlinetools --extract-only 1" \
-            --no-progress
+          # Chocolatey downloads the PostgreSQL installer from
+          # get.enterprisedb.com, which intermittently responds with HTTP 403
+          # and aborts the install. Retry a few times to absorb such transient
+          # download failures.
+          for attempt in 1 2 3; do
+            if choco install postgresql$INPUT_POSTGRES_VERSION \
+              --params "/Password:$INPUT_PASSWORD" \
+              --ia "--enable-components server,commandlinetools --extract-only 1" \
+              --no-progress; then
+              break
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              echo "::error::Failed to install PostgreSQL after $attempt attempts."
+              exit 1
+            fi
+
+            echo "::warning::choco install failed (attempt $attempt), retrying in 15s..."
+            sleep 15
+          done
 
           PG_BINDIR=$("$PROGRAMFILES/PostgreSQL/$INPUT_POSTGRES_VERSION/bin/pg_config.exe" --bindir)
           PG_LIBDIR=$("$PROGRAMFILES/PostgreSQL/$INPUT_POSTGRES_VERSION/bin/pg_config.exe" --libdir)


### PR DESCRIPTION
## Problem

On Windows the action installs PostgreSQL with `choco install postgresql<version>`. Chocolatey downloads the installer from `get.enterprisedb.com`, and that host intermittently responds with **HTTP 403 Forbidden**:

```
Attempt to get headers for https://get.enterprisedb.com/postgresql/postgresql-15.18-1-windows-x64.exe failed.
  The remote file either doesn't exist, is unauthorized, or is forbidden ... (403) Forbidden.
...
The install of postgresql15 was NOT successful.
Chocolatey installed 0/1 packages. 1 packages failed.
##[error]Process completed with exit code 148.
```

Because there is no retry, a single transient 403 fails the whole job even though re-running the install almost always succeeds. We hit this in pgjdbc CI (see e.g. [this run](https://github.com/pgjdbc/pgjdbc/actions/runs/27528349000/job/81360372512)).

## Fix

Wrap the `choco install` invocation in a small retry loop — 3 attempts, 15 s apart — so a transient download failure no longer breaks the build. The last attempt still propagates the failure, so a genuinely broken install is reported as before.

Only the Windows branch is affected; Linux (`apt`) and macOS (`brew`) paths are unchanged.