### PR TITLE
Add 'max-connections' input parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
           EXPECTED_CONNECTION_URI: postgresql://postgres:postgres@localhost:5432/postgres
           EXPECTED_SERVICE_NAME: postgres
           EXPECTED_SERVER_VERSION: "18"
+          EXPECTED_MAX_CONNECTIONS: "100"
           EXPECTED_SSL: false
 
   parametrized:
@@ -97,6 +98,7 @@ jobs:
           password: p@ss:/ word?#
           database: d@ta /#bas?:e
           port: 34837
+          max-connections: 200
           postgres-version: ${{ matrix.postgres-version }}
           ssl: true
         id: postgres
@@ -121,6 +123,7 @@ jobs:
           EXPECTED_CONNECTION_URI: "postgresql://user%3A%40%2F%20n%23m%2Be:p%40ss%3A%2F%20word%3F%23@localhost:34837/d%40ta%20%2F%23bas%3F%3Ae?sslmode=verify-ca&sslrootcert=${{ steps.postgres.outputs.certificate-path }}"
           EXPECTED_SERVICE_NAME: "user:@/ n#m+e"
           EXPECTED_SERVER_VERSION: ${{ matrix.postgres-version }}
+          EXPECTED_MAX_CONNECTIONS: "200"
           EXPECTED_SSL: true
 
   zizmor:

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ key features:
 | password         | The password of the user to set up.                                                      | `postgres`  |
 | database         | The database name to set up and grant permissions to the created user.                   | `postgres`  |
 | port             | The server port to listen on.                                                            | `5432`      |
+| max-connections  | The maximum number of concurrent connections to the server.                              | `100`       |
 | postgres-version | The PostgreSQL major version to install. Supported values: "14", "15", "16", "17", "18". | `18`        |
 
 #### Outputs
@@ -100,6 +101,7 @@ steps:
       password: sw0rdfish
       database: test
       port: 34837
+      max-connections: 200
       postgres-version: "14"
       ssl: true
     id: postgres

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: The server port to listen on.
     default: "5432"
     required: false
+  max-connections:
+    description: The maximum number of concurrent connections to the server.
+    default: "100"
+    required: false
   postgres-version:
     description: The PostgreSQL major version to install. Either "14", "15", "16", "17" or "18".
     default: "18"
@@ -177,6 +181,7 @@ runs:
         # directory we have no permissions to (owned by system postgres user).
         echo "unix_socket_directories = ''" >> "$PGDATA/postgresql.conf"
         echo "port = $INPUT_PORT" >> "$PGDATA/postgresql.conf"
+        echo "max_connections = $INPUT_MAX_CONNECTIONS" >> "$PGDATA/postgresql.conf"
 
         if [ "$INPUT_SSL" = "true" ]; then
           # On Windows, bash runs on top of MSYS2, which automatically converts
@@ -225,6 +230,7 @@ runs:
         echo "PGSERVICEFILE=$PGDATA/pg_service.conf" >> $GITHUB_ENV
       env:
         INPUT_PORT: ${{ inputs.port }}
+        INPUT_MAX_CONNECTIONS: ${{ inputs.max-connections }}
         INPUT_USERNAME: ${{ inputs.username }}
         INPUT_PASSWORD: ${{ inputs.password }}
         INPUT_DATABASE: ${{ inputs.database }}

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -148,6 +148,13 @@ def test_server_version(connection: psycopg.Connection):
     assert server_version.split(".")[0] == os.getenv("EXPECTED_SERVER_VERSION")
 
 
+def test_server_max_connections(connection: psycopg.Connection):
+    """Test that PostgreSQL's connection limit is expected."""
+
+    max_connections = connection.execute("SHOW MAX_CONNECTIONS").fetchone()[0]
+    assert max_connections == os.getenv("EXPECTED_MAX_CONNECTIONS")
+
+
 def test_server_ssl(connection: psycopg.Connection):
     """Test that connection is SSL encrypted."""
 


### PR DESCRIPTION
Some test suites require more than PostgreSQL's default limit of 100 concurrent connections. This patch adds a new `max-connections` input parameter that controls the server's `max_connections` setting. The parameter defaults to 100 to preserve the existing behavior.

Resolves: #66