### PR TITLE
Drop PostgreSQL 14 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,6 @@ jobs:
           - windows-2022
           - windows-2025
         postgres-version:
-          - "14"
           - "15"
           - "16"
           - "17"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ key features:
 | database         | The database name to set up and grant permissions to the created user.                   | `postgres`  |
 | port             | The server port to listen on.                                                            | `5432`      |
 | max-connections  | The maximum number of concurrent connections to the server.                              | `100`       |
-| postgres-version | The PostgreSQL major version to install. Supported values: "14", "15", "16", "17", "18". | `18`        |
+| postgres-version | The PostgreSQL major version to install. Supported values: "15", "16", "17", "18".       | `18`        |
 
 #### Outputs
 
@@ -102,7 +102,7 @@ steps:
       database: test
       port: 34837
       max-connections: 200
-      postgres-version: "14"
+      postgres-version: "15"
       ssl: true
     id: postgres
 

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ inputs:
     default: "100"
     required: false
   postgres-version:
-    description: The PostgreSQL major version to install. Either "14", "15", "16", "17" or "18".
+    description: The PostgreSQL major version to install. Either "15", "16", "17" or "18".
     default: "18"
     required: false
   ssl:
@@ -48,8 +48,8 @@ runs:
   steps:
     - name: Install PostgreSQL
       run: |
-        if [[ ! "$INPUT_POSTGRES_VERSION" =~ ^(14|15|16|17|18)$ ]]; then
-          echo "::error::postgres-version must be one of: 14, 15, 16, 17, 18."
+        if [[ ! "$INPUT_POSTGRES_VERSION" =~ ^(15|16|17|18)$ ]]; then
+          echo "::error::postgres-version must be one of: 15, 16, 17, 18."
           exit 1
         fi
 


### PR DESCRIPTION
PostgreSQL 14 will reach end-of-life soon (12 Nov 2026) and has already been deprecated by Homebrew. Drop it from the list of supported versions and the CI matrix.