### PR TITLE
Suppress Homebrew tap trust warnings in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,11 @@ jobs:
         with:
           persist-credentials: false
 
+      # Remove once https://github.com/actions/runner-images/issues/14232 is resolved.
+      - name: Trust preinstalled Homebrew taps
+        run: brew trust aws/tap
+        if: runner.os == 'macOS'
+
       - name: Run setup-postgres
         uses: ./
         id: postgres
@@ -89,6 +94,11 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
+
+      # Remove once https://github.com/actions/runner-images/issues/14232 is resolved.
+      - name: Trust preinstalled Homebrew taps
+        run: brew trust aws/tap
+        if: runner.os == 'macOS'
 
       - name: Run setup-postgres
         uses: ./


### PR DESCRIPTION
macOS runner images come with the preinstalled `aws/tap` Homebrew tap, but do not mark it as trusted. As a result, every `brew install` invocation produces a warning. Explicitly trust this tap in macOS CI jobs until runner images are fixed upstream [1].

[1]: https://github.com/actions/runner-images/issues/14232