### PR TITLE
Scope PostgreSQL state to action directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ key features:
 
 #### Outputs
 
-| Key              | Description                                      | Example                                             |
-|------------------|--------------------------------------------------|-----------------------------------------------------|
-| connection-uri   | The connection URI to connect to PostgreSQL.     | `postgresql://postgres:postgres@localhost/postgres` |
-| service-name     | The service name with connection parameters.     | `postgres`                                          |
-| certificate-path | The path to the server certificate if SSL is on. | `/home/runner/work/_temp/pgdata/server.crt`         |
+| Key              | Description                                      | Example                                                               |
+|------------------|--------------------------------------------------|-----------------------------------------------------------------------|
+| connection-uri   | The connection URI to connect to PostgreSQL.     | `postgresql://postgres:postgres@localhost/postgres`                   |
+| service-name     | The service name with connection parameters.     | `postgres`                                                            |
+| certificate-path | The path to the server certificate if SSL is on. | `$RUNNER_TEMP/action-setup-postgres/$GITHUB_ACTION/pgdata/server.crt` |
 
 #### User permissions
 

--- a/action.yml
+++ b/action.yml
@@ -140,8 +140,9 @@ runs:
 
     - name: Setup and start PostgreSQL
       run: |
-        PGDATA="$RUNNER_TEMP/pgdata"
-        PWFILE="$RUNNER_TEMP/pwfile"
+        PGDATA="$RUNNER_TEMP/action-setup-postgres/$GITHUB_ACTION/pgdata"
+        PWFILE="$RUNNER_TEMP/action-setup-postgres/$GITHUB_ACTION/pwfile"
+        mkdir -p "$RUNNER_TEMP/action-setup-postgres/$GITHUB_ACTION"
 
         DEFAULT_ENCODING="UTF-8"
         DEFAULT_LOCALE="en_US.$DEFAULT_ENCODING"
@@ -258,7 +259,7 @@ runs:
         PASSWORD_ENCODED=$(jq -rn --arg s "$INPUT_PASSWORD" '$s|@uri')
         DATABASE_ENCODED=$(jq -rn --arg s "$INPUT_DATABASE" '$s|@uri')
         CONNECTION_URI="postgresql://$USERNAME_ENCODED:$PASSWORD_ENCODED@localhost:$INPUT_PORT/$DATABASE_ENCODED"
-        CERTIFICATE_PATH="$RUNNER_TEMP/pgdata/server.crt"
+        CERTIFICATE_PATH="$RUNNER_TEMP/action-setup-postgres/$GITHUB_ACTION/pgdata/server.crt"
 
         if [ "$INPUT_SSL" = "true" ]; then
           # Although SSLMODE and SSLROOTCERT are specific to libpq options,

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -125,8 +125,9 @@ def test_environment_variables(is_windows: bool):
     # In case of Windows, there might be a mix of forward and backward slashes
     # as separators. So let's compare paths semantically instead.
     pg_servicefile = pathlib.Path(pg_environ.pop("PGSERVICEFILE", ""))
-    pg_servicefile_exp = pathlib.Path(os.environ["RUNNER_TEMP"], "pgdata", "pg_service.conf")
-    assert pg_servicefile.resolve() == pg_servicefile_exp.resolve()
+    runner_temp = pathlib.Path(os.environ["RUNNER_TEMP"])
+    pg_servicefile_rel = pg_servicefile.resolve().relative_to(runner_temp.resolve())
+    assert pg_servicefile_rel.full_match("action-setup-postgres/*/pgdata/pg_service.conf")
     
     if is_windows:
         pg_environ_exp = {


### PR DESCRIPTION
The action stores PostgreSQL data and temporary files directly in the runner's temporary directory using fixed names. This may cause conflicts when the action is invoked more than once in the same job.

Store these files under a directory derived from `GITHUB_ACTION` to keep each action invocation isolated.